### PR TITLE
Ensures that control is only disabled when aiming // allows players to vault / jump while armed

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1,7 +1,7 @@
 Citizen.CreateThread(function()
 	while true do
-		Citizen.Wait(5)
-		if IsPedArmed(GetPlayerPed(-1), 4 | 2) then 
+		Citizen.Wait(0)
+		if IsPedArmed(GetPlayerPed(-1), 4 | 2) and IsControlPressed(0, 25) then
 			DisableControlAction(0, 22, true)
 		end
 	end


### PR DESCRIPTION
This only changes 2 things:

The thread wait time to 0,

Adds a second check to ensure the player is aiming before disabling the control action, this allows for players to jump / vault while  armed which was not previously possible.